### PR TITLE
Update config.yml

### DIFF
--- a/data/config.yml
+++ b/data/config.yml
@@ -510,3 +510,149 @@ remediations:
     show_activities:
       selectors:
         - .pf-l-stack__item ins-c-playbookSummary__tabs button:contains('Activity')
+
+Red Hat OpenShift Cluster Manager
+cluster manager:
+  color: 2
+  pages: 
+    Clusters list:
+      url_rules:
+          - //cloud.redhat.com/openshift/
+    Clusters view:
+      url_rules:
+          - //cloud.redhat.com/openshift/details/*
+    Subscriptions:
+      url_rules:
+          - //cloud.redhat.com/openshift/subscriptions
+    Overview:
+      url_rules:
+          - //cloud.redhat.com/openshift/overview  
+  features:
+    "Clusters - Button: Create cluster":
+      selectors:
+        - 'button:contains("Create cluster")'
+    "Clusters - Filter: Cluster type" 
+      selectors:
+        - 'button:contains("Filter")'
+    "Clusters - Filter: Cluster type" 
+      selectors:
+        - 'button:contains("Filter")'
+    "Subscriptions - Button: Open Subscription Watch" 
+      selectors:
+        - 'a:contains("Open Subscription Watch")'
+
+Ansible
+automation analytics:
+color: 3
+  pages: 
+    Clusters:
+      url_rules:
+          - //cloud.redhat.com/ansible/automation-analytics/clusters
+    Organization Statistics:
+      url_rules:
+          - //cloud.redhat.com/ansible/automation-analytics/organization-statistics     
+    Automation Calculator:
+      url_rules:
+          - //cloud.redhat.com/ansible/automation-analytics/automation-calculator
+    Notifications:
+      url_rules:
+          - //cloud.redhat.com/ansible/automation-analytics/notifications
+
+automation hub:
+color: 4
+  pages: 
+    Collections list:
+      url_rules:
+          - //cloud.redhat.com/ansible/automation-hub/
+    Partners:
+      url_rules:
+          - //cloud.redhat.com/ansible/automation-hub/partners
+    My Namespaces list:
+      url_rules:
+          - //cloud.redhat.com/ansible/automation-hub/my-namespaces
+    My Namespaces view:
+      url_rules:
+          - //cloud.redhat.com/ansible/automation-hub/my-namespaces/*
+  features:
+    "Partners - Link: View collections":
+      selectors:
+        - 'a:contains("View collections")'
+
+automation services catalog:
+color: 5
+  pages: 
+    Products:
+      url_rules:
+          - //cloud.redhat.com/ansible/catalog/products/*
+    Portfolio:
+      url_rules:
+          - //cloud.redhat.com/ansible/catalog/portfolios/*
+    Orders:
+      url_rules:
+          - //cloud.redhat.com/ansible/catalog/orders/*          
+    Approval:
+      url_rules:
+          - //cloud.redhat.com/ansible/catalog/approval/* 
+
+automation services catalog:
+color: 5
+  pages: 
+    Products:
+      url_rules:
+          - //cloud.redhat.com/ansible/catalog/products/*
+    Portfolio:
+      url_rules:
+          - //cloud.redhat.com/ansible/catalog/portfolios/*
+    Orders:
+      url_rules:
+          - //cloud.redhat.com/ansible/catalog/orders/*          
+    Approval:
+      url_rules:
+          - //cloud.redhat.com/ansible/catalog/approval/*  
+
+Cost Management
+cost management:
+color: 6
+  pages: 
+    Overview:
+      url_rules:
+          - //cloud.redhat.com/cost-management/
+    Details - OpenShift:
+      url_rules:
+          - //cloud.redhat.com/cost-management/details/*
+    Details - Infrastructure:
+      url_rules:
+          - //cloud.redhat.com/cost-management/details/aws
+    Cost Models:
+      url_rules:
+          - //cloud.redhat.com/cost-management/cost-models
+
+Migration Services
+migration analytics:
+color: 7
+  pages: 
+    Getting Started:
+      url_rules: //cloud.redhat.com/migrations/migration-analytics/getting-started
+    Report - upload:
+      url_rules: //cloud.redhat.com/migrations/migration-analytics/reports/upload
+    Report - list:
+      url_rules: //cloud.redhat.com/migrations/migration-analytics/reports
+  features:
+    "Migration Analytics - Button: Create":
+      selectors:
+        - 'a:contains("Create")'
+
+Subscription Watch
+migration analytics:
+color: 8
+  pages: 
+    Getting Started:
+      url_rules: //cloud.redhat.com/migrations/migration-analytics/getting-started
+    Report - upload:
+      url_rules: //cloud.redhat.com/migrations/migration-analytics/reports/upload
+    Report - list:
+      url_rules: //cloud.redhat.com/migrations/migration-analytics/reports
+  features:
+    "Migration Analytics - Button: Create":
+      selectors:
+        - 'a:contains("Create")'

--- a/data/config.yml
+++ b/data/config.yml
@@ -1,4 +1,3 @@
----
 user_pref:
   pages:
     email:
@@ -12,9 +11,9 @@ user_pref:
 dashboard:
   color: 1
   pages:
-    Host list:
-      url_rules:
-        - //cloud.redhat.com/insights/dashboard
+      Host list:
+        url_rules:
+          - //cloud.redhat.com/insights/dashboard
   features:
     "Dashboard - Link: Systems running insights-client":
       selectors:
@@ -285,28 +284,23 @@ inventory:
         - //cloud.redhat.com/insights/inventory/*/
     Host view - General Information:
       url_rules:
-        - //cloud.redhat.com/insights/inventory/*/?appName=general_information
         - //cloud.redhat.com/insights/inventory/*/general_information
     Host view - Advisor:
       url_rules:
-        - //cloud.redhat.com/insights/inventory/*/?appName=advisor
         - //cloud.redhat.com/insights/inventory/*/advisor
         - //cloud.redhat.com/insights/inventory/*//advisor
     Host view - Vulnerability:
       url_rules:
-        - //cloud.redhat.com/insights/inventory/*/?appName=vulnerabilities
         - //cloud.redhat.com/insights/inventory/*/vulnerabilities
         - //cloud.redhat.com/insights/inventory/*//vulnerabilities
     Host view - Compliance:
       url_rules:
-        - //cloud.redhat.com/insights/inventory/*/?appName=compliance
         - //cloud.redhat.com/insights/inventory/*/compliance
         - //cloud.redhat.com/insights/inventory/*//compliance
     Host view - Patch:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/?appName=patch
-        - //cloud.redhat.com/insights/inventory/*/patch
-        - //cloud.redhat.com/insights/inventory/*//patch
+        url_rules:
+          - //cloud.redhat.com/insights/inventory/*/patch
+          - //cloud.redhat.com/insights/inventory/*//patch
   features:
     "Inventory - Filter: Status":
       selectors:
@@ -330,27 +324,6 @@ remediations:
     Host list:
       url_rules:
         - //cloud.redhat.com/insights/remediations
-  features:
-    add_to_remedation:
-      selectors:
-        - button:contains('Remediate')
-    download_playbook:
-      selectors:
-        - button:contains('Download Playbook')
-        - button:contains('Download playbook')
-    execute_playbook:
-      selectors:
-        - button:contains('Execute playbook')
-    remove_actions:
-      selectors:
-        - .ins-c-remediations-details-table__toolbar button:contains('Remove actions')
-    toggle_auto_reboot:
-      selectors:
-        - .ins-c-playbookSummary__overview button:contains('auto reboot')
-    show_activities:
-      selectors:
-        - .pf-l-stack__item ins-c-playbookSummary__tabs button:contains('Activity')
-
 
 register systems:
   color: 10
@@ -390,6 +363,9 @@ subscription watch:
     Red Hat OpenShift:
       url_rules:
         - //cloud.redhat.com/subscriptions/openshift-sw
+    Red Hat OpenShift:
+      url_rules:
+        - //cloud.redhat.com/subscriptions/openshift-sw
   features:
     "Red Hat Enterprise Linux - Link: Learn more about Subscription Watch reporting":
       selectors:
@@ -409,6 +385,9 @@ subscription watch:
     "Red Hat OpenShift - Link: Cores":
       selectors:
         - 'a:contains("Cores")'
+    "Red Hat OpenShift - Link: Cores":
+      selectors:
+        - 'a:contains("Subscription threshold")'
 
 rbac:
   features:
@@ -443,6 +422,7 @@ rbac:
     user_show:
       url_rules:
         - //cloud.redhat.com/settings/rbac/users/detail/*
+
 
 inventory:
   features:
@@ -550,19 +530,18 @@ cluster manager:
     "Clusters - Button: Create cluster":
       selectors:
         - 'button:contains("Create cluster")'
-    "Clusters - Filter: Cluster type" 
+    "Clusters - Filter: Cluster type": 
       selectors:
         - 'button:contains("Filter")'
-    "Clusters - Filter: Cluster type" 
+    "Clusters - Filter: Cluster type": 
       selectors:
         - 'button:contains("Filter")'
-    "Subscriptions - Button: Open Subscription Watch" 
+    "Subscriptions - Button: Open Subscription Watch": 
       selectors:
         - 'a:contains("Open Subscription Watch")'
 
-Ansible
 automation analytics:
-color: 3
+  color: 3
   pages: 
     Clusters:
       url_rules:
@@ -575,10 +554,10 @@ color: 3
           - //cloud.redhat.com/ansible/automation-analytics/automation-calculator
     Notifications:
       url_rules:
-          - //cloud.redhat.com/ansible/automation-analytics/notifications
+         - //cloud.redhat.com/ansible/automation-analytics/notifications
 
 automation hub:
-color: 4
+  color: 4
   pages: 
     Collections list:
       url_rules:
@@ -598,7 +577,7 @@ color: 4
         - 'a:contains("View collections")'
 
 automation services catalog:
-color: 5
+  color: 5
   pages: 
     Products:
       url_rules:
@@ -614,7 +593,7 @@ color: 5
           - //cloud.redhat.com/ansible/catalog/approval/* 
 
 automation services catalog:
-color: 5
+  color: 5
   pages: 
     Products:
       url_rules:
@@ -629,9 +608,8 @@ color: 5
       url_rules:
           - //cloud.redhat.com/ansible/catalog/approval/*  
 
-Cost Management
 cost management:
-color: 6
+  color: 6
   pages: 
     Overview:
       url_rules:
@@ -646,24 +624,8 @@ color: 6
       url_rules:
           - //cloud.redhat.com/cost-management/cost-models
 
-Migration Services
 migration analytics:
-color: 7
-  pages: 
-    Getting Started:
-      url_rules: //cloud.redhat.com/migrations/migration-analytics/getting-started
-    Report - upload:
-      url_rules: //cloud.redhat.com/migrations/migration-analytics/reports/upload
-    Report - list:
-      url_rules: //cloud.redhat.com/migrations/migration-analytics/reports
-  features:
-    "Migration Analytics - Button: Create":
-      selectors:
-        - 'a:contains("Create")'
-
-Subscription Watch
-migration analytics:
-color: 8
+  color: 7
   pages: 
     Getting Started:
       url_rules: //cloud.redhat.com/migrations/migration-analytics/getting-started

--- a/data/config.yml
+++ b/data/config.yml
@@ -511,8 +511,7 @@ remediations:
       selectors:
         - .pf-l-stack__item ins-c-playbookSummary__tabs button:contains('Activity')
 
-Red Hat OpenShift Cluster Manager
-cluster manager:
+cluster manager: 
   color: 2
   pages: 
     Clusters list:

--- a/data/config.yml
+++ b/data/config.yml
@@ -1,3 +1,4 @@
+---
 user_pref:
   pages:
     email:
@@ -11,9 +12,9 @@ user_pref:
 dashboard:
   color: 1
   pages:
-      Host list:
-        url_rules:
-          - //cloud.redhat.com/insights/dashboard
+    Host list:
+      url_rules:
+        - //cloud.redhat.com/insights/dashboard
   features:
     "Dashboard - Link: Systems running insights-client":
       selectors:
@@ -152,10 +153,6 @@ vulnerability:
     "CVEs - Filter: Publish date":
       selectors:
         - '[data-ouia-page-type="cves"] button:contains("Publish date")'
-    # Cant reliably target this one
-    # "Systems - Button: Export":
-    #   selectors:
-    #    - '[data-ouia-page-type="systems"] button.pf-c-dropdown__toggle'
 
 compliance:
   color: 4
@@ -231,10 +228,6 @@ patch:
     "Advisories - Button: Export":
       selectors:
         - '[data-ouia-page-type="advisories"] button.pf-c-dropdown__toggle'
-    # This one is scoped too high needs work
-    # "Systems - Button: Export":
-    #  selectors:
-    #    - '[data-ouia-page-type="systems"] button.pf-c-dropdown__toggle'
 
 drift:
   color: 6
@@ -273,57 +266,37 @@ policies:
       selectors:
         - 'button:contains("Create policy").pf-c-button'
 
-inventory:
-  color: 8
-  pages:
-    Host list:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory
-    Host view:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/
-    Host view - General Information:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/general_information
-    Host view - Advisor:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/advisor
-        - //cloud.redhat.com/insights/inventory/*//advisor
-    Host view - Vulnerability:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/vulnerabilities
-        - //cloud.redhat.com/insights/inventory/*//vulnerabilities
-    Host view - Compliance:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/compliance
-        - //cloud.redhat.com/insights/inventory/*//compliance
-    Host view - Patch:
-        url_rules:
-          - //cloud.redhat.com/insights/inventory/*/patch
-          - //cloud.redhat.com/insights/inventory/*//patch
-  features:
-    "Inventory - Filter: Status":
-      selectors:
-        - '[data-ouia-page-type="inventory"] button:contains("Status")'
-    "Inventory - Filter: Source":
-      selectors:
-        - '[data-ouia-page-type="inventory"] button:contains("Source")'
-    "Inventory - Filter: Tags":
-      selectors:
-        - '[data-ouia-page-type="inventory"] button:contains("Tags")'
-    "Inventory - Button: Delete":
-      selectors:
-        - '[data-ouia-page-type="inventory"] div:contains("Delete").pf-c-toolbar__item'
-    "Inventory - Link: Clear filters":
-      selectors:
-        - '[data-ouia-page-type="inventory"] button:contains("Clear filters").pf-c-button'
-
 remediations:
   color: 9
   pages:
-    Host list:
+    playbook_show:
       url_rules:
-        - //cloud.redhat.com/insights/remediations
+        - //cloud.redhat.com/insights/remediations/*
+        - //cloud.redhat.com/rhel/remediations/*
+    all:
+      url_rules:
+        - //cloud.redhat.com/rhel/remediations/**
+        - //cloud.redhat.com/insights/remediations/**
+  features:
+    add_to_remedation:
+      selectors:
+        - button:contains('Remediate')
+    download_playbook:
+      selectors:
+        - button:contains('Download Playbook')
+        - button:contains('Download playbook')
+    execute_playbook:
+      selectors:
+        - button:contains('Execute playbook')
+    remove_actions:
+      selectors:
+        - .ins-c-remediations-details-table__toolbar button:contains('Remove actions')
+    toggle_auto_reboot:
+      selectors:
+        - .ins-c-playbookSummary__overview button:contains('auto reboot')
+    show_activities:
+      selectors:
+        - .pf-l-stack__item ins-c-playbookSummary__tabs button:contains('Activity')
 
 register systems:
   color: 10
@@ -363,9 +336,6 @@ subscription watch:
     Red Hat OpenShift:
       url_rules:
         - //cloud.redhat.com/subscriptions/openshift-sw
-    Red Hat OpenShift:
-      url_rules:
-        - //cloud.redhat.com/subscriptions/openshift-sw
   features:
     "Red Hat Enterprise Linux - Link: Learn more about Subscription Watch reporting":
       selectors:
@@ -385,9 +355,6 @@ subscription watch:
     "Red Hat OpenShift - Link: Cores":
       selectors:
         - 'a:contains("Cores")'
-    "Red Hat OpenShift - Link: Cores":
-      selectors:
-        - 'a:contains("Subscription threshold")'
 
 rbac:
   features:
@@ -423,154 +390,67 @@ rbac:
       url_rules:
         - //cloud.redhat.com/settings/rbac/users/detail/*
 
-
-inventory:
-  features:
-    list_show_tags:
-      selectors:
-        - '[data-ouia-page-type="inventory"] .ins-c-tag-count'
-    list_clear_filters:
-      selectors:
-        - '[data-ouia-page-type="inventory"] button:contains("Clear filters")'
-    list_kabab:
-      selectors:
-        - '[data-ouia-page-type="inventory"] .pf-c-dropdown__toggle.pf-m-plain'
-    list_filter_name:
-      selectors:
-        - '[data-ouia-page-type="inventory"] .pf-c-dropdown__menu-item:contains("Name")'
-    list_filter_status:
-      selectors:
-        - '[data-ouia-page-type="inventory"] .pf-c-dropdown__menu-item:contains("Status")'
-    list_filter_source:
-      selectors:
-        - '[data-ouia-page-type="inventory"] .pf-c-dropdown__menu-item:contains("Source")'
-    list_filter_tags:
-      selectors:
-        - '[data-ouia-page-type="inventory"] .pf-c-dropdown__menu-item:contains("Tags")'
-    show_delete:
-      selectors:
-        - '[data-ouia-page-type="inventory"] button:contains("Delete")'
-
-  pages:
-    landing:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory
-        - //cloud.redhat.com/rhel/inventory
-    system_show:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*
-        - //cloud.redhat.com/rhel/inventory/*
-        - //cloud.redhat.com/insights/inventory/*//general_information
-        - //cloud.redhat.com/insights/inventory/*/general_information
-    system_show_advisor:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/advisor
-        - //cloud.redhat.com/insights/inventory/*//advisor
-        - //cloud.redhat.com/rhel/inventory/*/advisor
-    system_show_vuln:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/vulnerabilities
-        - //cloud.redhat.com/insights/inventory/*//vulnerabilities
-    system_show_compliance:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/compliance
-        - //cloud.redhat.com/insights/inventory/*//compliance
-    system_show_patch:
-      url_rules:
-        - //cloud.redhat.com/insights/inventory/*/patch
-        - //cloud.redhat.com/insights/inventory/*//patch
-
-remediations:
-  pages:
-    playbook_show:
-      url_rules:
-        - //cloud.redhat.com/insights/remediations/*
-        - //cloud.redhat.com/rhel/remediations/*
-    all:
-      url_rules:
-        - //cloud.redhat.com/rhel/remediations/**
-        - //cloud.redhat.com/insights/remediations/**
-  features:
-    add_to_remedation:
-      selectors:
-        - button:contains('Remediate')
-    download_playbook:
-      selectors:
-        - button:contains('Download Playbook')
-        - button:contains('Download playbook')
-    execute_playbook:
-      selectors:
-        - button:contains('Execute playbook')
-    remove_actions:
-      selectors:
-        - .ins-c-remediations-details-table__toolbar button:contains('Remove actions')
-    toggle_auto_reboot:
-      selectors:
-        - .ins-c-playbookSummary__overview button:contains('auto reboot')
-    show_activities:
-      selectors:
-        - .pf-l-stack__item ins-c-playbookSummary__tabs button:contains('Activity')
-
-cluster manager: 
+cluster manager:
   color: 2
-  pages: 
+  pages:
     Clusters list:
       url_rules:
-          - //cloud.redhat.com/openshift/
+        - //cloud.redhat.com/openshift/
     Clusters view:
       url_rules:
-          - //cloud.redhat.com/openshift/details/*
+        - //cloud.redhat.com/openshift/details/*
     Subscriptions:
       url_rules:
-          - //cloud.redhat.com/openshift/subscriptions
+        - //cloud.redhat.com/openshift/subscriptions
     Overview:
       url_rules:
-          - //cloud.redhat.com/openshift/overview  
+        - //cloud.redhat.com/openshift/overview
   features:
     "Clusters - Button: Create cluster":
       selectors:
         - 'button:contains("Create cluster")'
-    "Clusters - Filter: Cluster type": 
+    "Clusters - Filter: Cluster type":
       selectors:
         - 'button:contains("Filter")'
-    "Clusters - Filter: Cluster type": 
-      selectors:
-        - 'button:contains("Filter")'
-    "Subscriptions - Button: Open Subscription Watch": 
+    "Subscriptions - Button: Open Subscription Watch":
       selectors:
         - 'a:contains("Open Subscription Watch")'
 
 automation analytics:
   color: 3
-  pages: 
+  pages:
     Clusters:
       url_rules:
-          - //cloud.redhat.com/ansible/automation-analytics/clusters
+        - //cloud.redhat.com/ansible/automation-analytics/clusters
     Organization Statistics:
       url_rules:
-          - //cloud.redhat.com/ansible/automation-analytics/organization-statistics     
+        - //cloud.redhat.com/ansible/automation-analytics/organization-statistics
     Automation Calculator:
       url_rules:
-          - //cloud.redhat.com/ansible/automation-analytics/automation-calculator
+        - //cloud.redhat.com/ansible/automation-analytics/automation-calculator
     Notifications:
       url_rules:
-         - //cloud.redhat.com/ansible/automation-analytics/notifications
+        - //cloud.redhat.com/ansible/automation-analytics/notifications
+  features:
+    "Clusters - Filter: Past week":
+      selectors:
+        - '[data-ouia-page-group="ansible"][data-ouia-page-type="clusters"] option:contains("Past week")'
 
 automation hub:
   color: 4
-  pages: 
+  pages:
     Collections list:
       url_rules:
-          - //cloud.redhat.com/ansible/automation-hub/
+        - //cloud.redhat.com/ansible/automation-hub/
     Partners:
       url_rules:
-          - //cloud.redhat.com/ansible/automation-hub/partners
+        - //cloud.redhat.com/ansible/automation-hub/partners
     My Namespaces list:
       url_rules:
-          - //cloud.redhat.com/ansible/automation-hub/my-namespaces
+        - //cloud.redhat.com/ansible/automation-hub/my-namespaces
     My Namespaces view:
       url_rules:
-          - //cloud.redhat.com/ansible/automation-hub/my-namespaces/*
+        - //cloud.redhat.com/ansible/automation-hub/my-namespaces/*
   features:
     "Partners - Link: View collections":
       selectors:
@@ -578,61 +458,48 @@ automation hub:
 
 automation services catalog:
   color: 5
-  pages: 
+  pages:
     Products:
       url_rules:
-          - //cloud.redhat.com/ansible/catalog/products/*
+        - //cloud.redhat.com/ansible/catalog/products/*
     Portfolio:
       url_rules:
-          - //cloud.redhat.com/ansible/catalog/portfolios/*
+        - //cloud.redhat.com/ansible/catalog/portfolios/*
     Orders:
       url_rules:
-          - //cloud.redhat.com/ansible/catalog/orders/*          
+        - //cloud.redhat.com/ansible/catalog/orders/*
     Approval:
       url_rules:
-          - //cloud.redhat.com/ansible/catalog/approval/* 
-
-automation services catalog:
-  color: 5
-  pages: 
-    Products:
-      url_rules:
-          - //cloud.redhat.com/ansible/catalog/products/*
-    Portfolio:
-      url_rules:
-          - //cloud.redhat.com/ansible/catalog/portfolios/*
-    Orders:
-      url_rules:
-          - //cloud.redhat.com/ansible/catalog/orders/*          
-    Approval:
-      url_rules:
-          - //cloud.redhat.com/ansible/catalog/approval/*  
+        - //cloud.redhat.com/ansible/catalog/approval/*
 
 cost management:
   color: 6
-  pages: 
+  pages:
     Overview:
       url_rules:
-          - //cloud.redhat.com/cost-management/
+        - //cloud.redhat.com/cost-management/
     Details - OpenShift:
       url_rules:
-          - //cloud.redhat.com/cost-management/details/*
+        - //cloud.redhat.com/cost-management/details/*
     Details - Infrastructure:
       url_rules:
-          - //cloud.redhat.com/cost-management/details/aws
+        - //cloud.redhat.com/cost-management/details/aws
     Cost Models:
       url_rules:
-          - //cloud.redhat.com/cost-management/cost-models
+        - //cloud.redhat.com/cost-management/cost-models
 
 migration analytics:
   color: 7
-  pages: 
+  pages:
     Getting Started:
-      url_rules: //cloud.redhat.com/migrations/migration-analytics/getting-started
+      url_rules:
+        - //cloud.redhat.com/migrations/migration-analytics/getting-started
     Report - upload:
-      url_rules: //cloud.redhat.com/migrations/migration-analytics/reports/upload
+      url_rules:
+        - //cloud.redhat.com/migrations/migration-analytics/reports/upload
     Report - list:
-      url_rules: //cloud.redhat.com/migrations/migration-analytics/reports
+      url_rules:
+        - //cloud.redhat.com/migrations/migration-analytics/reports
   features:
     "Migration Analytics - Button: Create":
       selectors:

--- a/lint.py
+++ b/lint.py
@@ -22,18 +22,20 @@ with open(CONFIG, 'r') as config_yml:
         if not 'pages'    in group:
             print('Error: no *pages* section found in group "{}"'.format(name))
             sys.exit(1)
-        if not 'features' in group:
-            print('Error: no *features* section found in group "{}"'.format(name))
-            sys.exit(1)
 
-        for feature_name, feature in group['features'].items():
-            if 'selectors' not in feature:
-                print('Error: found a feature without a "selectors" array ({} -> {})'.format(name, feature_name))
-                sys.exit(1)
-            for selector in feature['selectors']:
-                if REG_IDS.match(selector):
-                    print('Error: found an id-NN pattern in a feature selector ({} -> {} -> {})'.format(name, feature_name, selector))
+        # if not 'features' in group:
+        #     print('Error: no *features* section found in group "{}"'.format(name))
+        #     sys.exit(1)
+
+        if 'features' in group:
+            for feature_name, feature in group['features'].items():
+                if 'selectors' not in feature:
+                    print('Error: found a feature without a "selectors" array ({} -> {})'.format(name, feature_name))
                     sys.exit(1)
+                for selector in feature['selectors']:
+                    if REG_IDS.match(selector):
+                        print('Error: found an id-NN pattern in a feature selector ({} -> {} -> {})'.format(name, feature_name, selector))
+                        sys.exit(1)
 
         for page_name, page in group['pages'].items():
             for url in page['url_rules']:


### PR DESCRIPTION
Added Page and Feature Tags for OpenShift Cluster Manager, Ansible Automation Platform, Cost Management (though I didn't tag Features - I don't have enough access to see any features on pages), and Migration Services. So with Insights and Subscription Watch already tagged in our older versions of this file, this should cover all current pages and features in c.rh.com 

For all tags - is there a way we can add an indication for bundle? Basically so if it's within Insights, Cluster Manager, etc (maybe in the Group name?), we can easily group by bundle. Let me know if that makes sense from your perspective? 

Thanks @iphands !