### PR TITLE
Adding parameterized URLs that pendo supports,

### DIFF
--- a/data/config.yml
+++ b/data/config.yml
@@ -128,12 +128,12 @@ advisor:
         - /insights/advisor/**
     Recommendations system:
       url_rules:
-        - /insights/advisor/recommendations/*/*
-        - /insights/recommendations/*/*
+        - /insights/advisor/recommendations/*rule_id*/*
+        - /insights/recommendations/*rule_id*/*
     Recommendations view:
       url_rules:
-        - /insights/advisor/recommendations/*
-        - /insights/recommendations/*
+        - /insights/advisor/recommendations/*rule_id*
+        - /insights/recommendations/*rule_id*
     Recommendations list:
       url_rules:
         - /insights/advisor/recommendations
@@ -146,7 +146,7 @@ advisor:
         - /insights/advisor/systems
     Topics view:
       url_rules:
-        - /insights/advisor/topics/*
+        - /insights/advisor/topics/*topic_id*
     Topics list:
       url_rules:
         - /insights/advisor/topics
@@ -504,9 +504,12 @@ cluster manager:
     Cluster view - Monitoring:
       url_rules:
         - /openshift/details/*#monitoring
-    Cluster view - Insights:
+    Cluster view - Insights recommendation view:
       url_rules:
         - /openshift/details/*#insights
+    Cluster view - Insights :
+      url_rules:
+        - /openshift/details/*/insights/*rule_id*
     Cluster view - Support:
       url_rules:
         - /openshift/details/*#support

--- a/data/config.yml
+++ b/data/config.yml
@@ -163,7 +163,7 @@ vulnerability:
         - /insights/vulnerability/cves
     CVE view:
       url_rules:
-        - /insights/vulnerability/cves/*
+        - /insights/vulnerability/cves/*cve_id*/
     Systems list:
       url_rules:
         - /insights/vulnerability/systems
@@ -258,7 +258,7 @@ patch:
         - /insights/patch/
     Advisory view:
       url_rules:
-        - /insights/patch/advisories/*/
+        - /insights/patch/advisories/*rhsa_id*/
     Systems list:
       url_rules:
         - /insights/patch/systems/
@@ -507,7 +507,7 @@ cluster manager:
     Cluster view - Insights recommendation view:
       url_rules:
         - /openshift/details/*#insights
-    Cluster view - Insights :
+    Cluster view - Insights:
       url_rules:
         - /openshift/details/*/insights/*rule_id*
     Cluster view - Support:


### PR DESCRIPTION
adding rule tracking for OpenShift Insights rec view.

See:
https://support.pendo.io/hc/en-us/articles/360032293371-Understanding-URLs-for-page-tagging#ParameterizedURLs

Also there was no rule for a OpenShift Insights rule view before.