### PR TITLE
Update drift comparison view url-rules

### DIFF
--- a/data/config.yml
+++ b/data/config.yml
@@ -317,7 +317,10 @@ drift:
         - /insights/drift
     Comparison view:
       url_rules:
-        - /insights/drift/*
+        - /insights/drift/?system_ids=*parameter*
+        - /insights/drift/?baseline_ids=*parameter*
+        - /insights/drift/?hsp_ids=*parameter*
+        - /insights/drift/?reference_id=*parameter*
     Baseline list:
       url_rules:
         - /insights/drift/baselines


### PR DESCRIPTION
Previously we were tracking any non-parameter string that followed `/drift/`. This was wrapping in any visit to `/drift/` as well as `/drift/baselines/*`.

This PR fixes that so we can track views on `/drift/` that include parameters. So now we can track when people are viewing a comparison.