### PR TITLE
Add feature to track drift comparison Export to CSV

### DIFF
--- a/data/config.yml
+++ b/data/config.yml
@@ -332,6 +332,9 @@ drift:
     "Baselines - Button: Create baseline":
       selectors:
         - '{} button#create-baseline-button:contains("Create baseline")'
+    "Comparison - Button: Export to CSV":
+      selectors:
+        - '{}[data-ouia-component-id="export-to-csv-dropdown-item-comparison"] button:contains("Export to CSV")'
 
 policies:
   color: 7


### PR DESCRIPTION
This PR adds a feature to track clicks on the "Export to CSV" dropdown item on the comparison table toolbar dropdown.