### PR TITLE
Patch: add a new link to advisory list analysis

### DIFF
--- a/data/config.yml
+++ b/data/config.yml
@@ -522,6 +522,7 @@ patch:
     Advisories list:
       url_rules:
         - /insights/patch/
+        - /insights/patch/advisories
     Advisory view:
       url_rules:
         - /insights/patch/advisories/*parameter*/


### PR DESCRIPTION
I was a bit late to push this change, my PR is already merged. Anyways, We have found out that advisories list analysis is not getting the actual traffic due to missing the link: **- /insights/patch/advisories**. 