### PR TITLE
Limit tracking in Advisor for OpenShift

### DIFF
--- a/data/openshift.yml
+++ b/data/openshift.yml
@@ -21,8 +21,8 @@ openshift:
     Cluster view - Insights.post01172021:
       url_rules:
         - /openshift/details/s/*#insights
-        - /openshift/insights/advisor
-        - /openshift/insights/advisor/**
+        - /openshift/insights/advisor/recommendations/**
+        - /openshift/insights/advisor/clusters/**
     Cluster view - Insights recommendation view.post01172021:
       url_rules:
         - /openshift/details/s/*/insights/*parameter*


### PR DESCRIPTION
We want to track only pages where customers can see specific recommendations for specific clusters. Overview pages are not entirely useful for this view.