### PR TITLE
Add missing pages to Insights for OCP All pages

### DIFF
--- a/data/insights-for-openshift.yml
+++ b/data/insights-for-openshift.yml
@@ -4,6 +4,9 @@ insights for openshift:
   pages:
     All pages.post04262021:
       url_rules:
+        - /openshift/insights/advisor
+        - /openshift/insights/advisor/**
+        - /openshift/insights/vulnerability/**
         - /openshift/subscriptions/**
         - /openshift/subscriptions
         - /openshift/quota


### PR DESCRIPTION
Add missing Advisor and (future) Vulnerability rules to the Insights for OpenShift All pages ruleset.