### PR TITLE
Add ansible, rhel, and openshift link selectors to services dropdown

### DIFF
--- a/data/crc.yml
+++ b/data/crc.yml
@@ -20,6 +20,7 @@ crc:
     Favorited services:
       url_rules:
         - /favoritedservices
+  data-ouia-component-id="AllServices-Dropdown-Ansible"
   features:
     _scope: '[data-ouia-app-id="landing"]'
     "Selector: Beta switcher":
@@ -34,6 +35,15 @@ crc:
     "Find an app or service":
       selectors:
         - '{} button:contains("Find an app or service")'
+    "Apps & Services Dropdown - Ansible":
+      selectors:
+        - '{} [data-ouia-component-id="AllServices-Dropdown-Ansible"]'
+    "Apps & Services Dropdown - RHEL":
+      selectors:
+        - '{} [data-ouia-component-id="AllServices-Dropdown-RHEL"]'
+    "Apps & Services Dropdown - Openshift":
+      selectors:
+        - '{} [data-ouia-component-id="AllServices-Dropdown-Openshift"]'
     "Apps & Services Dropdown - Application Services: Overview":
       selectors:
         - '{} a:contains("Overview")[href="application-services/overview"]'
@@ -175,6 +185,15 @@ crc:
     "Apps & Services Dropdown - Ansible Automation Platform: Overview":
       selectors:
         - '{} a:contains("Overview")[href="ansible/ansible-dashboard"]'
+    "Apps & Services Dropdown Sitewide - Ansible":
+      selectors:
+        - '{} [data-ouia-component-id="AllServices-Dropdown-Ansible"]'
+    "Apps & Services Dropdown Sitewide - RHEL":
+      selectors:
+        - '{} [data-ouia-component-id="AllServices-Dropdown-RHEL"]'
+    "Apps & Services Dropdown Sitewide - Openshift":
+      selectors:
+        - '{} [data-ouia-component-id="AllServices-Dropdown-Openshift"]'
     "Apps & Services Dropdown Sitewide - Application Services: Overview":
       selectors:
         - 'a:contains("Overview")[href="application-services/overview"]'

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,6 +1,6 @@
 # Adding Data
 
-Each application should have their own file inside of `/data/APP.yml`. Whenever changing your selectors or pages, make sure you are upding the correct file.
+Each application should have their own file inside of `/data/APP.yml`. Whenever changing your selectors or pages, make sure you are updating the correct file.
 
 ## Adding a new app
 
@@ -67,7 +67,7 @@ For `Example Feature 1`, the full selector would be:
 
 `[data-ouia-bundle="foo"][data-ouia-app-id="bar"] .pf-c-button:contains("Wow!")`
 
-Spacing of the `{}` is important, because without the trailing space, like in the second exmaple, there is no space after the `data-ouia-app-id`.
+Spacing of the `{}` is important, because without the trailing space, like in the second example, there is no space after the `data-ouia-app-id`.
 
 If you are testing out selectors and want to double check your work before contributing, you can do
 


### PR DESCRIPTION
For [RHCLOUD-33602](https://issues.redhat.com/browse/RHCLOUD-33602), currently waiting for a new frontend release with these `ouia` selectors added